### PR TITLE
Fix HTML validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This list was last updated for WordPress 6.3.
 
 All emails sent by WordPress go through the pluggable <a href="https://developer.wordpress.org/reference/functions/wp_mail/"><code>wp_mail()</code></a> function. The following general-purpose filters and actions are used in this function:
 
-<table width="100%" style="width:100%">
+<table>
 	<tr>
 		<th scope="row" valign="top" align="left">Filters</th>
 		<td>


### PR DESCRIPTION
From #34

This is the only error!
(while ignoring `The .+ attribute on the “th” element is obsolete`)